### PR TITLE
Adapt to new Kanboard hook template:task:sidebar:information

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -10,7 +10,7 @@ class Plugin extends Base
     {
         $this->route->addRoute('/plugin/relation_graph/:task_id', 'relationgraph', 'show', 'relationgraph');
 
-        $this->template->hook->attach('template:task:sidebar', 'relationgraph:task/sidebar');
+        $this->template->hook->attach('template:task:sidebar:information', 'relationgraph:task/sidebar');
     }
 
     public function getPluginName()

--- a/Template/task/show.php
+++ b/Template/task/show.php
@@ -1,5 +1,9 @@
+<div class="task-show-title color-<?= $task['color_id'] ?>">
+    <h2><?= $this->text->e($task['title']) ?></h2>
+</div>
+
 <div class="page-header">
-    <h2><?= t('Relation Graph') ?> : <?= $title ?></h2>
+    <h2><?= t('Relation graph') ?></h2>
 </div>
 
 <style type="text/css">

--- a/Template/task/sidebar.php
+++ b/Template/task/sidebar.php
@@ -2,17 +2,15 @@
     $routerController = $this->app->getRouterController();
     $routerPlugin = $this->app->getPluginName();
 
-    $active = $routerController == 'relationgraph' && $routerPlugin == 'RelationGraph';
+    $active = $routerController == 'Relationgraph' && $routerPlugin == 'Relationgraph';
 ?>
-<ul>
-    <li class="<?= $active ? 'active' : '' ?>">
-        <i class="fa fa-rotate-left fa-fw"></i>
-        <?= $this->url->link(
-            'Relation Graph',
-            'relationgraph',
-            'show',
-            ['plugin' => 'relationgraph', 'task_id' => $task['id']]
-        ) ?>
-    </li>
-</ul>
+<li class="<?= $active ? 'active' : '' ?>">
+    <i class="fa fa-rotate-left fa-fw"></i>
+    <?= $this->url->link(
+        'Relation graph',
+        'relationgraph',
+        'show',
+        ['plugin' => 'relationgraph', 'task_id' => $task['id']]
+    ) ?>
+</li>
 


### PR DESCRIPTION
There is a new hook on Kanboard `template:task:sidebar:information`. I used it to display the "Relation graph" link in the right place. I removed the uppercase on "Graph" to fit the other links on the sidebar.
